### PR TITLE
fix: update baseUrl for GitHub pages deployment

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -13,7 +13,7 @@ const config: Config = {
   url: "https://phatsss.github.io",
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: "/",
+  baseUrl: "/phatsss-blog/",
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
The baseUrl was changed from "/" to "/phatsss-blog/" to properly serve the site under GitHub Pages, which requires the project name in the base path.