### PR TITLE
chore(docusaurus): add deployment config for GitHub Pages

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -23,6 +23,9 @@ const config: Config = {
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
 
+  deploymentBranch: "gh-pages",
+  githubHost: "github.com",
+  githubPort: "22",
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you
   // may want to replace "en" with "zh-Hans".


### PR DESCRIPTION
Add deploymentBranch, githubHost, and githubPort configurations to support GitHub Pages deployment